### PR TITLE
Fix 'Onchain' string typo

### DIFF
--- a/ZKSyncSDK/Classes/Model/Auth/ChangePubKeyOnchain.swift
+++ b/ZKSyncSDK/Classes/Model/Auth/ChangePubKeyOnchain.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 public struct ChangePubKeyOnchain: ChangePubKeyVariant {
-    public let type: ChangePubKeyAuthType = .onchain
+    public let type: ChangePubKeyAuthType = .Onchain
     public let bytes: Data = Data(repeating: 0, count: 32)
     
     enum CodingKeys: String, CodingKey {

--- a/ZKSyncSDK/Classes/Model/Auth/ChangePubKeyVariant.swift
+++ b/ZKSyncSDK/Classes/Model/Auth/ChangePubKeyVariant.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 public enum ChangePubKeyAuthType: String, Encodable {
-    case onchain
+    case Onchain
     case ECDSA
     case CREATE2
 }


### PR DESCRIPTION
Hi, been testing the SDK, and found that 'OnChain' ChangePubKey was rejected against ropsten deployment. Checked the JS SDK, and found that the actual string should be 'OnChain' instead of 'onchain'.

https://github.com/matter-labs/zksync/blob/master/etc/test_config/sdk/test-vectors.json#L69