### PR TITLE
Code cleanup.

### DIFF
--- a/Examples/CocoaPods/Podfile.lock
+++ b/Examples/CocoaPods/Podfile.lock
@@ -21,7 +21,6 @@ PODS:
     - Starscream (~> 3.1.0)
   - ZKSync (0.0.3):
     - Alamofire (~> 5.0)
-    - BigInt
     - web3swift
     - ZKSyncCrypto (= 0.0.9-spm)
   - ZKSyncCrypto (0.0.9-spm)
@@ -52,7 +51,7 @@ SPEC CHECKSUMS:
   secp256k1.c: db47b726585d80f027423682eb369729e61b3b20
   Starscream: 4bb2f9942274833f7b4d296a55504dcfc7edb7b0
   web3swift: 0f097eafe1d08f478694b882581b85a01afb6633
-  ZKSync: 03c1084e51816b08c9937e546234ac7e5f62c488
+  ZKSync: f681734a3d5e81834a895fcad9c468fe9724e659
   ZKSyncCrypto: ff0662eb0cff69ab3e40564a45a07cbcafe1ccf0
 
 PODFILE CHECKSUM: 19f2bc7b77d611151be6a9850baac7dbb61b1e85

--- a/Examples/CocoaPods/ZKSyncExample.xcodeproj/project.pbxproj
+++ b/Examples/CocoaPods/ZKSyncExample.xcodeproj/project.pbxproj
@@ -41,7 +41,7 @@
 			containerPortal = 607FACC81AFB9204008FA782 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = 607FACCF1AFB9204008FA782;
-			remoteInfo = ZKSyncSDK;
+			remoteInfo = ZKSync;
 		};
 /* End PBXContainerItemProxy section */
 
@@ -224,7 +224,7 @@
 			dependencies = (
 			);
 			name = ZKSyncExample;
-			productName = ZKSyncSDK;
+			productName = ZKSync;
 			productReference = 607FACD01AFB9204008FA782 /* ZKSyncExample.app */;
 			productType = "com.apple.product-type.application";
 		};

--- a/Examples/CocoaPods/ZKSyncExample/Base.lproj/Main.storyboard
+++ b/Examples/CocoaPods/ZKSyncExample/Base.lproj/Main.storyboard
@@ -11,7 +11,7 @@
         <!--Network-->
         <scene sceneID="EMe-eF-And">
             <objects>
-                <tableViewController id="MEj-0P-ygz" customClass="NetworkSelectionTableViewController" customModule="ZKSyncSDK_Example" customModuleProvider="target" sceneMemberID="viewController">
+                <tableViewController id="MEj-0P-ygz" customClass="NetworkSelectionTableViewController" customModule="ZKSyncExample" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="static" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" id="5f8-4l-yJt">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -112,7 +112,7 @@
         <!--Contract Address View Controller-->
         <scene sceneID="UmO-Br-w3q">
             <objects>
-                <viewController id="orw-Fw-7P1" customClass="ContractAddressViewController" customModule="ZKSyncSDK_Example" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="orw-Fw-7P1" customClass="ContractAddressViewController" customModule="ZKSyncExample" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="0pK-Mx-Lv2"/>
                         <viewControllerLayoutGuide type="bottom" id="RcI-2L-r5C"/>
@@ -178,7 +178,7 @@
         <!--Send Deposit-->
         <scene sceneID="tiU-zp-RzI">
             <objects>
-                <viewController id="0Gp-My-hdg" customClass="DepositViewController" customModule="ZKSyncSDK_Example" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="0Gp-My-hdg" customClass="DepositViewController" customModule="ZKSyncExample" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="Mcm-Rq-vqQ"/>
                         <viewControllerLayoutGuide type="bottom" id="qzb-qO-LFD"/>
@@ -243,7 +243,7 @@
         <!--Method Selection Table View Controller-->
         <scene sceneID="W2F-eC-Kcu">
             <objects>
-                <tableViewController id="U1i-LY-vcA" customClass="MethodSelectionTableViewController" customModule="ZKSyncSDK_Example" customModuleProvider="target" sceneMemberID="viewController">
+                <tableViewController id="U1i-LY-vcA" customClass="MethodSelectionTableViewController" customModule="ZKSyncExample" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="static" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" id="U46-0d-plh">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -497,7 +497,7 @@
         <!--Token Price View Controller-->
         <scene sceneID="Zhj-Vz-Pxz">
             <objects>
-                <viewController id="ti3-rv-2by" customClass="TokenPriceViewController" customModule="ZKSyncSDK_Example" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="ti3-rv-2by" customClass="TokenPriceViewController" customModule="ZKSyncExample" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="Ljf-XL-SPM"/>
                         <viewControllerLayoutGuide type="bottom" id="dQa-DI-kFI"/>
@@ -550,7 +550,7 @@
         <!--Transaction Fee View Controller-->
         <scene sceneID="c9m-Fs-IhG">
             <objects>
-                <viewController id="0qX-D5-G4p" customClass="TransactionFeeViewController" customModule="ZKSyncSDK_Example" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="0qX-D5-G4p" customClass="TransactionFeeViewController" customModule="ZKSyncExample" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="0QX-k9-63h"/>
                         <viewControllerLayoutGuide type="bottom" id="sy4-kC-k55"/>
@@ -732,7 +732,7 @@
         <!--Account State View Controller-->
         <scene sceneID="Q7S-z9-XLZ">
             <objects>
-                <viewController id="cbn-2e-WFc" customClass="AccountStateViewController" customModule="ZKSyncSDK_Example" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="cbn-2e-WFc" customClass="AccountStateViewController" customModule="ZKSyncExample" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="Kda-ts-X1H"/>
                         <viewControllerLayoutGuide type="bottom" id="Tro-0e-1Rk"/>
@@ -762,7 +762,7 @@
                                 <rect key="frame" x="0.0" y="132" width="375" height="535"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <prototypes>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="Depositing" id="1q6-d2-aOy" customClass="DepositingBalanceTableViewCell" customModule="ZKSyncSDK_Example" customModuleProvider="target">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="Depositing" id="1q6-d2-aOy" customClass="DepositingBalanceTableViewCell" customModule="ZKSyncExample" customModuleProvider="target">
                                         <rect key="frame" x="0.0" y="28" width="375" height="78.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="1q6-d2-aOy" id="Sg3-3A-vVC">
@@ -851,7 +851,7 @@
         <!--Send Withdraw-->
         <scene sceneID="Sak-ay-G9z">
             <objects>
-                <viewController id="aRk-Cc-Ibr" customClass="WithdrawViewController" customModule="ZKSyncSDK_Example" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="aRk-Cc-Ibr" customClass="WithdrawViewController" customModule="ZKSyncExample" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="DDI-2W-9p7"/>
                         <viewControllerLayoutGuide type="bottom" id="Yjv-SF-feQ"/>
@@ -916,7 +916,7 @@
         <!--Send Transfer-->
         <scene sceneID="Ecp-0H-vR0">
             <objects>
-                <viewController id="09R-OI-qAN" customClass="TransferViewController" customModule="ZKSyncSDK_Example" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="09R-OI-qAN" customClass="TransferViewController" customModule="ZKSyncExample" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="yeF-63-lHe"/>
                         <viewControllerLayoutGuide type="bottom" id="XJG-K6-grT"/>

--- a/Examples/CocoaPods/ZKSyncExample/StateSectionHeaderView.xib
+++ b/Examples/CocoaPods/ZKSyncExample/StateSectionHeaderView.xib
@@ -11,7 +11,7 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <view contentMode="scaleToFill" id="iN0-l3-epB" customClass="StateSectionHeaderView" customModule="ZKSyncSDK_Example" customModuleProvider="target">
+        <view contentMode="scaleToFill" id="iN0-l3-epB" customClass="StateSectionHeaderView" customModule="ZKSyncExample" customModuleProvider="target">
             <rect key="frame" x="0.0" y="0.0" width="590" height="187"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>

--- a/README.md
+++ b/README.md
@@ -5,14 +5,14 @@
 
 ## Requirements
 
-- iOS 11.0+ / macOS 10.12+ / tvOS 10.0+ / watchOS 3.0+
+- iOS 11.0+
 - Xcode 11+
 - Swift 5.0+
 
 
 ## Installation
 
-* CocoaPods: `pod 'ZKSync'`
+- CocoaPods: `pod 'ZKSync'`
 
 ## License
 

--- a/Sources/ZKSync/Ethereum/EthereumProvider.swift
+++ b/Sources/ZKSync/Ethereum/EthereumProvider.swift
@@ -1,6 +1,6 @@
 //
 //  EthereumProvider.swift
-//  ZKSyncSDK
+//  ZKSync
 //
 //  Created by Eugene Belyakov on 17/01/2021.
 //

--- a/Sources/ZKSync/Ethereum/ZkSync.swift
+++ b/Sources/ZKSync/Ethereum/ZkSync.swift
@@ -1,6 +1,6 @@
 //
 //  ZkSync.swift
-//  ZKSyncSDK
+//  ZKSync
 //
 //  Created by Eugene Belyakov on 19/01/2021.
 //

--- a/Sources/ZKSync/Ethereum/ZkSyncABI.swift
+++ b/Sources/ZKSync/Ethereum/ZkSyncABI.swift
@@ -1,6 +1,6 @@
 //
 //  ZkSyncABI.swift
-//  ZKSyncSDK
+//  ZKSync
 //
 //  Created by Eugene Belyakov on 19/01/2021.
 //

--- a/Sources/ZKSync/Extensions/BigInt+Extensions.swift
+++ b/Sources/ZKSync/Extensions/BigInt+Extensions.swift
@@ -1,6 +1,6 @@
 //
 //  BigInt+Extensions.swift
-//  ZKSyncSDK
+//  ZKSync
 //
 //  Made with ❤️ by Matter Labs on 10/23/20
 //

--- a/Sources/ZKSync/Extensions/BinaryInteger+Extensions.swift
+++ b/Sources/ZKSync/Extensions/BinaryInteger+Extensions.swift
@@ -1,6 +1,6 @@
 //
 //  BinaryInteger+Extensions.swift
-//  ZKSyncSDK
+//  ZKSync
 //
 //  Created by Eugene Belyakov on 11/01/2021.
 //

--- a/Sources/ZKSync/Extensions/String+Extensions.swift
+++ b/Sources/ZKSync/Extensions/String+Extensions.swift
@@ -1,6 +1,6 @@
 //
 //  String+Extensions.swift
-//  ZKSyncSDK
+//  ZKSync
 //
 //  Made with ❤️ by Matter Labs on 10/23/20
 //

--- a/Sources/ZKSync/Model/AccountState.swift
+++ b/Sources/ZKSync/Model/AccountState.swift
@@ -1,6 +1,6 @@
 //
 //  AccountState.swift
-//  ZKSyncSDK
+//  ZKSync
 //
 //  Created by Eugene Belyakov on 06/01/2021.
 //

--- a/Sources/ZKSync/Model/Block/BlockInfo.swift
+++ b/Sources/ZKSync/Model/Block/BlockInfo.swift
@@ -1,6 +1,6 @@
 //
 //  BlockInfo.swift
-//  ZKSyncSDK
+//  ZKSync
 //
 //  Created by Eugene Belyakov on 16/01/2021.
 //

--- a/Sources/ZKSync/Model/ChainId.swift
+++ b/Sources/ZKSync/Model/ChainId.swift
@@ -1,6 +1,6 @@
 //
 //  ChainId.swift
-//  ZKSyncSDK
+//  ZKSync
 //
 //  Created by Eugene Belyakov on 11/01/2021.
 //

--- a/Sources/ZKSync/Model/Contract/ContractAddress.swift
+++ b/Sources/ZKSync/Model/Contract/ContractAddress.swift
@@ -1,6 +1,6 @@
 //
 //  ContractAddress.swift
-//  ZKSyncSDK
+//  ZKSync
 //
 //  Created by Eugene Belyakov on 06/01/2021.
 //

--- a/Sources/ZKSync/Model/EthOpInfo.swift
+++ b/Sources/ZKSync/Model/EthOpInfo.swift
@@ -1,6 +1,6 @@
 //
 //  EthOpInfo.swift
-//  ZKSyncSDK
+//  ZKSync
 //
 //  Created by Eugene Belyakov on 16/01/2021.
 //

--- a/Sources/ZKSync/Model/Signature.swift
+++ b/Sources/ZKSync/Model/Signature.swift
@@ -1,6 +1,6 @@
 //
 //  Signature.swift
-//  ZKSyncSDK
+//  ZKSync
 //
 //  Created by Eugene Belyakov on 11/01/2021.
 //

--- a/Sources/ZKSync/Model/Token/Token.swift
+++ b/Sources/ZKSync/Model/Token/Token.swift
@@ -7,7 +7,6 @@
 
 import Foundation
 import BigInt
-import web3swift
 
 public struct Token: TokenId, Decodable {
     

--- a/Sources/ZKSync/Model/Token/Token.swift
+++ b/Sources/ZKSync/Model/Token/Token.swift
@@ -1,6 +1,6 @@
 //
 //  Token.swift
-//  ZKSyncSDK
+//  ZKSync
 //
 //  Created by Eugene Belyakov on 06/01/2021.
 //

--- a/Sources/ZKSync/Model/Token/Tokens.swift
+++ b/Sources/ZKSync/Model/Token/Tokens.swift
@@ -1,6 +1,6 @@
 //
 //  Tokens.swift
-//  ZKSyncSDK
+//  ZKSync
 //
 //  Created by Eugene Belyakov on 13/01/2021.
 //

--- a/Sources/ZKSync/Model/TransactionDetails.swift
+++ b/Sources/ZKSync/Model/TransactionDetails.swift
@@ -1,6 +1,6 @@
 //
 //  TransactionDetails.swift
-//  ZKSyncSDK
+//  ZKSync
 //
 //  Created by Eugene Belyakov on 16/01/2021.
 //

--- a/Sources/ZKSync/Model/TransactionFee/TransactionFee.swift
+++ b/Sources/ZKSync/Model/TransactionFee/TransactionFee.swift
@@ -1,6 +1,6 @@
 //
 //  TransactionFee.swift
-//  ZKSyncSDK
+//  ZKSync
 //
 //  Created by Eugene Belyakov on 13/01/2021.
 //

--- a/Sources/ZKSync/Model/TransactionFee/TransactionFeeBatchRequest.swift
+++ b/Sources/ZKSync/Model/TransactionFee/TransactionFeeBatchRequest.swift
@@ -1,6 +1,6 @@
 //
 //  TransactionFeeBatchRequest.swift
-//  ZKSyncSDK
+//  ZKSync
 //
 //  Created by Eugene Belyakov on 08/01/2021.
 //

--- a/Sources/ZKSync/Model/TransactionFee/TransactionFeeDetails.swift
+++ b/Sources/ZKSync/Model/TransactionFee/TransactionFeeDetails.swift
@@ -1,6 +1,6 @@
 //
 //  TransactionFeeDetails.swift
-//  ZKSyncSDK
+//  ZKSync
 //
 //  Created by Eugene Belyakov on 08/01/2021.
 //

--- a/Sources/ZKSync/Model/TransactionFee/TransactionFeeRequest.swift
+++ b/Sources/ZKSync/Model/TransactionFee/TransactionFeeRequest.swift
@@ -1,6 +1,6 @@
 //
 //  TransactionFeeRequest.swift
-//  ZKSyncSDK
+//  ZKSync
 //
 //  Created by Eugene Belyakov on 08/01/2021.
 //

--- a/Sources/ZKSync/Model/TransactionFee/TransactionType.swift
+++ b/Sources/ZKSync/Model/TransactionFee/TransactionType.swift
@@ -1,6 +1,6 @@
 //
 //  TransactionType.swift
-//  ZKSyncSDK
+//  ZKSync
 //
 //  Created by Eugene Belyakov on 08/01/2021.
 //

--- a/Sources/ZKSync/Model/TransactionFee/TransactionTypeAddressPair.swift
+++ b/Sources/ZKSync/Model/TransactionFee/TransactionTypeAddressPair.swift
@@ -1,6 +1,6 @@
 //
 //  TransactionTypeAddressPair.swift
-//  ZKSyncSDK
+//  ZKSync
 //
 //  Created by Eugene Belyakov on 08/01/2021.
 //

--- a/Sources/ZKSync/Model/Transactions/Batch/TransactionBatchRequest.swift
+++ b/Sources/ZKSync/Model/Transactions/Batch/TransactionBatchRequest.swift
@@ -1,6 +1,6 @@
 //
 //  TransactionBatchRequest.swift
-//  ZKSyncSDK
+//  ZKSync
 //
 //  Created by Eugene Belyakov on 16/01/2021.
 //

--- a/Sources/ZKSync/Model/Transactions/Batch/TransactionSignaturePair.swift
+++ b/Sources/ZKSync/Model/Transactions/Batch/TransactionSignaturePair.swift
@@ -1,6 +1,6 @@
 //
 //  TransactionSignaturePair.swift
-//  ZKSyncSDK
+//  ZKSync
 //
 //  Created by Eugene Belyakov on 16/01/2021.
 //

--- a/Sources/ZKSync/Model/Transactions/ChangePubKey.swift
+++ b/Sources/ZKSync/Model/Transactions/ChangePubKey.swift
@@ -1,6 +1,6 @@
 //
 //  ChangePubKey.swift
-//  ZKSyncSDK
+//  ZKSync
 //
 //  Created by Eugene Belyakov on 11/01/2021.
 //

--- a/Sources/ZKSync/Model/Transactions/ForcedExit.swift
+++ b/Sources/ZKSync/Model/Transactions/ForcedExit.swift
@@ -1,6 +1,6 @@
 //
 //  ForcedExit.swift
-//  ZKSyncSDK
+//  ZKSync
 //
 //  Created by Eugene Belyakov on 12/01/2021.
 //

--- a/Sources/ZKSync/Model/Transactions/Transfer.swift
+++ b/Sources/ZKSync/Model/Transactions/Transfer.swift
@@ -1,6 +1,6 @@
 //
 //  Transfer.swift
-//  ZKSyncSDK
+//  ZKSync
 //
 //  Created by Eugene Belyakov on 12/01/2021.
 //

--- a/Sources/ZKSync/Model/Transactions/Withdraw.swift
+++ b/Sources/ZKSync/Model/Transactions/Withdraw.swift
@@ -1,6 +1,6 @@
 //
 //  Withdraw.swift
-//  ZKSyncSDK
+//  ZKSync
 //
 //  Created by Eugene Belyakov on 12/01/2021.
 //

--- a/Sources/ZKSync/Model/Transactions/ZkSyncTransaction.swift
+++ b/Sources/ZKSync/Model/Transactions/ZkSyncTransaction.swift
@@ -1,6 +1,6 @@
 //
 //  ZkSyncTransaction.swift
-//  ZKSyncSDK
+//  ZKSync
 //
 //  Created by Eugene Belyakov on 13/01/2021.
 //

--- a/Sources/ZKSync/Provider/DefaultProvider+Accounts.swift
+++ b/Sources/ZKSync/Provider/DefaultProvider+Accounts.swift
@@ -1,6 +1,6 @@
 //
 //  Provider+Accounts.swift
-//  ZKSyncSDK
+//  ZKSync
 //
 //  Made with ❤️ by Matter Labs on 10/23/20
 //

--- a/Sources/ZKSync/Provider/DefaultProvider+ConfirmationsForEthOpAmount.swift
+++ b/Sources/ZKSync/Provider/DefaultProvider+ConfirmationsForEthOpAmount.swift
@@ -1,6 +1,6 @@
 //
 //  DefaultProvider+ConfirmationsForEthOpAmount.swift
-//  ZKSyncSDK
+//  ZKSync
 //
 //  Created by Eugene Belyakov on 16/01/2021.
 //

--- a/Sources/ZKSync/Provider/DefaultProvider+ContractAddress.swift
+++ b/Sources/ZKSync/Provider/DefaultProvider+ContractAddress.swift
@@ -1,6 +1,6 @@
 //
 //  Provider+ContractAddress.swift
-//  ZKSyncSDK
+//  ZKSync
 //
 //  Made with ❤️ by Matter Labs on 10/23/20
 //

--- a/Sources/ZKSync/Provider/DefaultProvider+EthOpInfo.swift
+++ b/Sources/ZKSync/Provider/DefaultProvider+EthOpInfo.swift
@@ -1,6 +1,6 @@
 //
 //  DefaultProvider+EthOpInfo.swift
-//  ZKSyncSDK
+//  ZKSync
 //
 //  Created by Eugene Belyakov on 16/01/2021.
 //

--- a/Sources/ZKSync/Provider/DefaultProvider+EthTxForWithdrawal.swift
+++ b/Sources/ZKSync/Provider/DefaultProvider+EthTxForWithdrawal.swift
@@ -1,6 +1,6 @@
 //
 //  DefaultProvider+EthTxForWithdrawal.swift
-//  ZKSyncSDK
+//  ZKSync
 //
 //  Created by Eugene Belyakov on 22/01/2021.
 //

--- a/Sources/ZKSync/Provider/DefaultProvider+TokenPrice.swift
+++ b/Sources/ZKSync/Provider/DefaultProvider+TokenPrice.swift
@@ -1,6 +1,6 @@
 //
 //  Provider+TokenPrice.swift
-//  ZKSyncSDK
+//  ZKSync
 //
 //  Made with ❤️ by Matter Labs on 10/23/20
 //

--- a/Sources/ZKSync/Provider/DefaultProvider+Tokens.swift
+++ b/Sources/ZKSync/Provider/DefaultProvider+Tokens.swift
@@ -1,6 +1,6 @@
 //
 //  DefaultProvider+Tokens.swift
-//  ZKSyncSDK
+//  ZKSync
 //
 //  Created by Eugene Belyakov on 13/01/2021.
 //

--- a/Sources/ZKSync/Provider/DefaultProvider+TransactionDetails.swift
+++ b/Sources/ZKSync/Provider/DefaultProvider+TransactionDetails.swift
@@ -1,6 +1,6 @@
 //
 //  DefaultProvider+TransactionDetails.swift
-//  ZKSyncSDK
+//  ZKSync
 //
 //  Created by Eugene Belyakov on 16/01/2021.
 //

--- a/Sources/ZKSync/Provider/DefaultProvider.swift
+++ b/Sources/ZKSync/Provider/DefaultProvider.swift
@@ -1,6 +1,6 @@
 //
 //  DefaultProvider.swift
-//  ZKSyncSDK
+//  ZKSync
 //
 //  Created by Eugene Belyakov on 13/01/2021.
 //

--- a/Sources/ZKSync/Provider/Provider.swift
+++ b/Sources/ZKSync/Provider/Provider.swift
@@ -1,6 +1,6 @@
 //
 //  Provider.swift
-//  ZKSyncSDK
+//  ZKSync
 //
 //  Made with ❤️ by Matter Labs on 10/23/20
 //

--- a/Sources/ZKSync/Provider/TransactionFee/DefaultProvider+TransactionFee.swift
+++ b/Sources/ZKSync/Provider/TransactionFee/DefaultProvider+TransactionFee.swift
@@ -1,6 +1,6 @@
 //
 //  Provider+TransactionFee.swift
-//  ZKSyncSDK
+//  ZKSync
 //
 //  Made with ❤️ by Matter Labs on 10/23/20
 //

--- a/Sources/ZKSync/Provider/TransactionFee/TransactionFeeBatchRequest+Encoding.swift
+++ b/Sources/ZKSync/Provider/TransactionFee/TransactionFeeBatchRequest+Encoding.swift
@@ -1,6 +1,6 @@
 //
 //  TransactionFeeBatchRequest+Encoding.swift
-//  ZKSyncSDK
+//  ZKSync
 //
 //  Created by Eugene Belyakov on 08/01/2021.
 //

--- a/Sources/ZKSync/Provider/TransactionFee/TransactionFeeRequest+Encoding.swift
+++ b/Sources/ZKSync/Provider/TransactionFee/TransactionFeeRequest+Encoding.swift
@@ -1,6 +1,6 @@
 //
 //  TransactionFeeRequest+Encoding.swift
-//  ZKSyncSDK
+//  ZKSync
 //
 //  Created by Eugene Belyakov on 08/01/2021.
 //

--- a/Sources/ZKSync/Provider/TransactionFee/TransactionType+Encoding.swift
+++ b/Sources/ZKSync/Provider/TransactionFee/TransactionType+Encoding.swift
@@ -1,6 +1,6 @@
 //
 //  TransactionType+Encoding.swift
-//  ZKSyncSDK
+//  ZKSync
 //
 //  Created by Eugene Belyakov on 08/01/2021.
 //

--- a/Sources/ZKSync/Provider/Transactions/DefaultProvider+Transactions.swift
+++ b/Sources/ZKSync/Provider/Transactions/DefaultProvider+Transactions.swift
@@ -1,6 +1,6 @@
 //
 //  DefaultProvider+Transactions.swift
-//  ZKSyncSDK
+//  ZKSync
 //
 //  Created by Eugene Belyakov on 13/01/2021.
 //

--- a/Sources/ZKSync/Provider/Transactions/TransactionRequest.swift
+++ b/Sources/ZKSync/Provider/Transactions/TransactionRequest.swift
@@ -1,6 +1,6 @@
 //
 //  TransactionRequest.swift
-//  ZKSyncSDK
+//  ZKSync
 //
 //  Created by Eugene Belyakov on 13/01/2021.
 //

--- a/Sources/ZKSync/Signer/Ethereum/DefaultEthSigner+Messages.swift
+++ b/Sources/ZKSync/Signer/Ethereum/DefaultEthSigner+Messages.swift
@@ -1,6 +1,6 @@
 //
 //  EthSigner+Messages.swift
-//  ZKSyncSDK
+//  ZKSync
 //
 //  Created by Eugene Belyakov on 11/01/2021.
 //

--- a/Sources/ZKSync/Signer/Ethereum/DefaultEthSigner+Utils.swift
+++ b/Sources/ZKSync/Signer/Ethereum/DefaultEthSigner+Utils.swift
@@ -1,6 +1,6 @@
 //
 //  EthSigner+Utils.swift
-//  ZKSyncSDK
+//  ZKSync
 //
 //  Created by Eugene Belyakov on 11/01/2021.
 //

--- a/Sources/ZKSync/Signer/Ethereum/DefaultEthSigner.swift
+++ b/Sources/ZKSync/Signer/Ethereum/DefaultEthSigner.swift
@@ -1,6 +1,6 @@
 //
 //  DefaultEthSigner.swift
-//  ZKSyncSDK
+//  ZKSync
 //
 //  Created by Eugene Belyakov on 22/01/2021.
 //

--- a/Sources/ZKSync/Signer/Ethereum/EthSignature.swift
+++ b/Sources/ZKSync/Signer/Ethereum/EthSignature.swift
@@ -1,6 +1,6 @@
 //
 //  EthSignature.swift
-//  ZKSyncSDK
+//  ZKSync
 //
 //  Created by Eugene Belyakov on 09/01/2021.
 //

--- a/Sources/ZKSync/Signer/Ethereum/EthSigner.swift
+++ b/Sources/ZKSync/Signer/Ethereum/EthSigner.swift
@@ -1,6 +1,6 @@
 //
 //  EthSigner.swift
-//  ZKSyncSDK
+//  ZKSync
 //
 //  Created by Eugene Belyakov on 06/01/2021.
 //

--- a/Sources/ZKSync/Signer/Ethereum/EthSignerError.swift
+++ b/Sources/ZKSync/Signer/Ethereum/EthSignerError.swift
@@ -1,6 +1,6 @@
 //
 //  EthSignerError.swift
-//  ZKSyncSDK
+//  ZKSync
 //
 //  Created by Eugene Belyakov on 11/01/2021.
 //

--- a/Sources/ZKSync/Signer/Utils/Bits.swift
+++ b/Sources/ZKSync/Signer/Utils/Bits.swift
@@ -1,6 +1,6 @@
 //
 //  Bits.swift
-//  ZKSyncSDK
+//  ZKSync
 //
 //  Created by Eugene Belyakov on 11/01/2021.
 //

--- a/Sources/ZKSync/Signer/Utils/Utils.swift
+++ b/Sources/ZKSync/Signer/Utils/Utils.swift
@@ -1,6 +1,6 @@
 //
 //  Utils.swift
-//  ZKSyncSDK
+//  ZKSync
 //
 //  Created by Eugene Belyakov on 11/01/2021.
 //

--- a/Sources/ZKSync/Signer/ZKSync/ZkSigner.swift
+++ b/Sources/ZKSync/Signer/ZKSync/ZkSigner.swift
@@ -1,6 +1,6 @@
 //
 //  ZkSigner.swift
-//  ZKSyncSDK
+//  ZKSync
 //
 //  Created by Eugene Belyakov on 11/01/2021.
 //

--- a/Sources/ZKSync/Transport/Error.swift
+++ b/Sources/ZKSync/Transport/Error.swift
@@ -1,6 +1,6 @@
 //
 //  Error.swift
-//  ZKSyncSDK
+//  ZKSync
 //
 //  Made with ❤️ by Matter Labs on 10/23/20
 //

--- a/Sources/ZKSync/Transport/HTTPTransport.swift
+++ b/Sources/ZKSync/Transport/HTTPTransport.swift
@@ -1,6 +1,6 @@
 //
 //  HTTPTransport.swift
-//  ZKSyncSDK
+//  ZKSync
 //
 //  Created by Eugene Belyakov on 04/01/2021.
 //

--- a/Sources/ZKSync/Transport/Request.swift
+++ b/Sources/ZKSync/Transport/Request.swift
@@ -1,6 +1,6 @@
 //
 //  Request.swift
-//  ZKSyncSDK
+//  ZKSync
 //
 //  Made with ❤️ by Matter Labs on 10/23/20
 //

--- a/Sources/ZKSync/Transport/Response.swift
+++ b/Sources/ZKSync/Transport/Response.swift
@@ -1,6 +1,6 @@
 //
 //  Response.swift
-//  ZKSyncSDK
+//  ZKSync
 //
 //  Made with ❤️ by Matter Labs on 10/23/20
 //

--- a/Sources/ZKSync/Transport/Transport.swift
+++ b/Sources/ZKSync/Transport/Transport.swift
@@ -1,6 +1,6 @@
 //
 //  Transport.swift
-//  ZKSyncSDK
+//  ZKSync
 //
 //  Made with ❤️ by Matter Labs on 10/23/20
 //

--- a/Sources/ZKSync/Types.swift
+++ b/Sources/ZKSync/Types.swift
@@ -1,6 +1,6 @@
 //
 //  Types.swift
-//  ZKSyncSDK
+//  ZKSync
 //
 //  Made with ❤️ by Matter Labs on 10/23/20
 //

--- a/Sources/ZKSync/Types/ZKSyncError.swift
+++ b/Sources/ZKSync/Types/ZKSyncError.swift
@@ -1,6 +1,6 @@
 //
 //  Error.swift
-//  ZKSyncSDK
+//  ZKSync
 //
 //  Made with ❤️ by Matter Labs on 10/23/20
 //

--- a/Sources/ZKSync/Wallet/DefaultWallet+ChangePubKey.swift
+++ b/Sources/ZKSync/Wallet/DefaultWallet+ChangePubKey.swift
@@ -1,6 +1,6 @@
 //
 //  DefaultWallet+ChangePubKey.swift
-//  ZKSyncSDK
+//  ZKSync
 //
 //  Created by Eugene Belyakov on 16/01/2021.
 //

--- a/Sources/ZKSync/Wallet/DefaultWallet+ForcedExit.swift
+++ b/Sources/ZKSync/Wallet/DefaultWallet+ForcedExit.swift
@@ -1,6 +1,6 @@
 //
 //  DefaultWallet+ForcedExit.swift
-//  ZKSyncSDK
+//  ZKSync
 //
 //  Created by Eugene Belyakov on 16/01/2021.
 //

--- a/Sources/ZKSync/Wallet/DefaultWallet+Promises.swift
+++ b/Sources/ZKSync/Wallet/DefaultWallet+Promises.swift
@@ -1,6 +1,6 @@
 //
 //  DefaultWallet+Promises.swift
-//  ZKSyncSDK
+//  ZKSync
 //
 //  Created by Eugene Belyakov on 16/01/2021.
 //

--- a/Sources/ZKSync/Wallet/DefaultWallet+Transfer.swift
+++ b/Sources/ZKSync/Wallet/DefaultWallet+Transfer.swift
@@ -1,6 +1,6 @@
 //
 //  DefaultWallet+Transfer.swift
-//  ZKSyncSDK
+//  ZKSync
 //
 //  Created by Eugene Belyakov on 16/01/2021.
 //

--- a/Sources/ZKSync/Wallet/DefaultWallet+Withdraw.swift
+++ b/Sources/ZKSync/Wallet/DefaultWallet+Withdraw.swift
@@ -1,6 +1,6 @@
 //
 //  DefaultWallet+Withdraw.swift
-//  ZKSyncSDK
+//  ZKSync
 //
 //  Created by Eugene Belyakov on 16/01/2021.
 //

--- a/Sources/ZKSync/Wallet/DefaultWallet.swift
+++ b/Sources/ZKSync/Wallet/DefaultWallet.swift
@@ -1,6 +1,6 @@
 //
 //  DefaultWallet.swift
-//  ZKSyncSDK
+//  ZKSync
 //
 //  Created by Eugene Belyakov on 06/01/2021.
 //

--- a/Sources/ZKSync/Wallet/DefaultWallet.swift
+++ b/Sources/ZKSync/Wallet/DefaultWallet.swift
@@ -19,7 +19,7 @@ enum DefaultWalletError: Error {
 public class DefaultWallet: Wallet {
     
     private let group = DispatchGroup()
-    private let deliveryQueue = DispatchQueue(label: "com.zksyncsdk.wallet")
+    private let deliveryQueue = DispatchQueue(label: "com.zksync.wallet")
     
     public let provider: Provider
     internal let ethSigner: EthSigner

--- a/Sources/ZKSync/Wallet/SignedTransaction.swift
+++ b/Sources/ZKSync/Wallet/SignedTransaction.swift
@@ -1,6 +1,6 @@
 //
 //  SignedTransaction.swift
-//  ZKSyncSDK
+//  ZKSync
 //
 //  Created by Eugene Belyakov on 13/01/2021.
 //

--- a/Sources/ZKSync/Wallet/Wallet+PromiseInterface.swift
+++ b/Sources/ZKSync/Wallet/Wallet+PromiseInterface.swift
@@ -1,6 +1,6 @@
 //
 //  Wallet+PromiseInterface.swift
-//  ZKSyncSDK
+//  ZKSync
 //
 //  Created by Eugene Belyakov on 22/01/2021.
 //

--- a/Sources/ZKSync/Wallet/Wallet.swift
+++ b/Sources/ZKSync/Wallet/Wallet.swift
@@ -1,6 +1,6 @@
 //
 //  Wallet.swift
-//  ZKSyncSDK
+//  ZKSync
 //
 //  Created by Eugene Belyakov on 06/01/2021.
 //

--- a/ZKSync.podspec
+++ b/ZKSync.podspec
@@ -13,13 +13,13 @@ zkSync is a scaling and privacy engine for Ethereum. Its current functionality s
     s.author           = { "The Matter Labs team" => "hello@matterlabs.dev" }
   
     s.ios.deployment_target = "11.0"
-    s.swift_version = '5.0'
+    s.swift_version    = '5.0'
   
-    s.source       = { :git => "https://github.com/zksync-sdk/zksync-swift.git", :tag => "#{s.version}" }
+    s.source           = { :git => "https://github.com/zksync-sdk/zksync-swift.git", :tag => "#{s.version}" }
     
-    s.dependency 'BigInt'
     s.dependency 'ZKSyncCrypto', '0.0.9-spm'
     s.dependency 'Alamofire', '~> 5.0'
     s.dependency 'web3swift'
+
     s.source_files = 'Sources/ZKSync/**/*'
 end


### PR DESCRIPTION
In scope of this PR:
- `BigInt` was removed from the list of dependencies in CocoaPods as it's part of `web3swift` anyway.
- Renamed previously used `ZKSyncSDK` library name to `ZKSync`.
- Updated `README.md` to contain only iOS as a supported platform.