### PR TITLE
Update to fork of `web3swift`.

### DIFF
--- a/Examples/CocoaPods/Podfile.lock
+++ b/Examples/CocoaPods/Podfile.lock
@@ -1,27 +1,27 @@
 PODS:
   - Alamofire (5.4.3)
-  - BigInt (4.0.0)
-  - CryptoSwift (1.0.0)
-  - PromiseKit (6.8.5):
-    - PromiseKit/CorePromise (= 6.8.5)
-    - PromiseKit/Foundation (= 6.8.5)
-    - PromiseKit/UIKit (= 6.8.5)
-  - PromiseKit/CorePromise (6.8.5)
-  - PromiseKit/Foundation (6.8.5):
+  - BigInt (5.2.0)
+  - CryptoSwift (1.4.1)
+  - PromiseKit (6.15.3):
+    - PromiseKit/CorePromise (= 6.15.3)
+    - PromiseKit/Foundation (= 6.15.3)
+    - PromiseKit/UIKit (= 6.15.3)
+  - PromiseKit/CorePromise (6.15.3)
+  - PromiseKit/Foundation (6.15.3):
     - PromiseKit/CorePromise
-  - PromiseKit/UIKit (6.8.5):
+  - PromiseKit/UIKit (6.15.3):
     - PromiseKit/CorePromise
   - secp256k1.c (0.1.2)
-  - Starscream (3.1.1)
-  - web3swift (2.3.0):
-    - BigInt (~> 4.0)
-    - CryptoSwift (~> 1.0.0)
-    - PromiseKit (~> 6.8.4)
+  - Starscream (4.0.4)
+  - web3swift-zksync (2.4.0-zksync):
+    - BigInt (~> 5.2)
+    - CryptoSwift (~> 1.4.0)
+    - PromiseKit (~> 6.15.3)
     - secp256k1.c (~> 0.1)
-    - Starscream (~> 3.1.0)
+    - Starscream (~> 4.0.4)
   - ZKSync (0.0.3):
     - Alamofire (~> 5.0)
-    - web3swift
+    - web3swift-zksync (= 2.4.0-zksync)
     - ZKSyncCrypto (= 0.0.9-spm)
   - ZKSyncCrypto (0.0.9-spm)
 
@@ -36,7 +36,7 @@ SPEC REPOS:
     - PromiseKit
     - secp256k1.c
     - Starscream
-    - web3swift
+    - web3swift-zksync
     - ZKSyncCrypto
 
 EXTERNAL SOURCES:
@@ -45,13 +45,13 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Alamofire: e447a2774a40c996748296fa2c55112fdbbc42f9
-  BigInt: 2aad1a9942dc932ec8b84290d2c564a3d76f97ab
-  CryptoSwift: d81eeaa59dc5a8d03720fe919a6fd07b51f7439f
-  PromiseKit: 9616b0afef31eae56ab9ce044c8ec2b8612a15cd
+  BigInt: f668a80089607f521586bbe29513d708491ef2f7
+  CryptoSwift: 0bc800a7e6a24c4fc9ebeab97d44b0d5f73a78bd
+  PromiseKit: 3b2b6995e51a954c46dbc550ce3da44fbfb563c5
   secp256k1.c: db47b726585d80f027423682eb369729e61b3b20
-  Starscream: 4bb2f9942274833f7b4d296a55504dcfc7edb7b0
-  web3swift: 0f097eafe1d08f478694b882581b85a01afb6633
-  ZKSync: f681734a3d5e81834a895fcad9c468fe9724e659
+  Starscream: 5178aed56b316f13fa3bc55694e583d35dd414d9
+  web3swift-zksync: f069cac51c03dd98e28fc4480d64b4e9b91e2aff
+  ZKSync: 2c3a7a3ca241473fea02b6fc6275a84484536c11
   ZKSyncCrypto: ff0662eb0cff69ab3e40564a45a07cbcafe1ccf0
 
 PODFILE CHECKSUM: 19f2bc7b77d611151be6a9850baac7dbb61b1e85

--- a/Examples/CocoaPods/Tests/IntegrationFlowTests.swift
+++ b/Examples/CocoaPods/Tests/IntegrationFlowTests.swift
@@ -8,7 +8,7 @@
 
 import XCTest
 @testable import ZKSync
-import web3swift
+import web3swift_zksync
 import PromiseKit
 import BigInt
 

--- a/Examples/CocoaPods/ZKSyncExample.xcodeproj/project.pbxproj
+++ b/Examples/CocoaPods/ZKSyncExample.xcodeproj/project.pbxproj
@@ -7,11 +7,11 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		380D91C941169690952DB8D8 /* Pods_ZKSyncExampleTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BD97EC8DA29277BABEA0B4E4 /* Pods_ZKSyncExampleTests.framework */; };
+		2158B05245B51FC3C3493E17 /* Pods_ZKSyncExampleTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B32A403170B6D034173CC57B /* Pods_ZKSyncExampleTests.framework */; };
 		443FFA2525B8DD8C000CDA8D /* ZkSignerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 443FFA2425B8DD8B000CDA8D /* ZkSignerTests.swift */; };
 		443FFA2925B8E1B8000CDA8D /* DefaultWalletTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 443FFA2825B8E1B8000CDA8D /* DefaultWalletTests.swift */; };
 		44E17F6F25B968C200ED4CED /* IntegrationFlowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44E17F6E25B968C200ED4CED /* IntegrationFlowTests.swift */; };
-		57E5048503FD0CE2FAD9DB48 /* Pods_ZKSyncExample.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1F174EC994B8F39BF71D99A6 /* Pods_ZKSyncExample.framework */; };
+		56AA71BB4AA87D3D74F326D2 /* Pods_ZKSyncExample.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8CDF95587ABAE1B9D20870B8 /* Pods_ZKSyncExample.framework */; };
 		8A9CAE4D2690A6FB00DABC41 /* ZKSync.podspec in Resources */ = {isa = PBXBuildFile; fileRef = 8A9CAE4B2690A6FA00DABC41 /* ZKSync.podspec */; };
 		8A9CAE4E2690A6FB00DABC41 /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = 8A9CAE4C2690A6FA00DABC41 /* README.md */; };
 		8A9CAE7D2690AA9000DABC41 /* TransferViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A9CAE672690AA9000DABC41 /* TransferViewController.swift */; };
@@ -46,12 +46,10 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		1F174EC994B8F39BF71D99A6 /* Pods_ZKSyncExample.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ZKSyncExample.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		2982254753DB1AAE2DABE522 /* Pods-ZKSyncExampleTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ZKSyncExampleTests.release.xcconfig"; path = "Target Support Files/Pods-ZKSyncExampleTests/Pods-ZKSyncExampleTests.release.xcconfig"; sourceTree = "<group>"; };
+		2940ABF5BAC9C36FDE824858 /* Pods-ZKSyncExample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ZKSyncExample.release.xcconfig"; path = "Target Support Files/Pods-ZKSyncExample/Pods-ZKSyncExample.release.xcconfig"; sourceTree = "<group>"; };
 		443FFA2425B8DD8B000CDA8D /* ZkSignerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZkSignerTests.swift; sourceTree = "<group>"; };
 		443FFA2825B8E1B8000CDA8D /* DefaultWalletTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultWalletTests.swift; sourceTree = "<group>"; };
 		44E17F6E25B968C200ED4CED /* IntegrationFlowTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntegrationFlowTests.swift; sourceTree = "<group>"; };
-		4C3C624F3C39C15665764F2A /* Pods-ZKSyncExampleTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ZKSyncExampleTests.debug.xcconfig"; path = "Target Support Files/Pods-ZKSyncExampleTests/Pods-ZKSyncExampleTests.debug.xcconfig"; sourceTree = "<group>"; };
 		607FACD01AFB9204008FA782 /* ZKSyncExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ZKSyncExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		607FACE51AFB9204008FA782 /* ZKSyncExampleTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ZKSyncExampleTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		607FACEA1AFB9204008FA782 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -77,9 +75,11 @@
 		8A9CAE7A2690AA9000DABC41 /* WalletConsumer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WalletConsumer.swift; sourceTree = "<group>"; };
 		8A9CAE7B2690AA9000DABC41 /* StateSectionHeaderView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = StateSectionHeaderView.xib; sourceTree = "<group>"; };
 		8A9CAE7C2690AA9000DABC41 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		91946EDCC7AA66ED1F337C9D /* Pods-ZKSyncExample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ZKSyncExample.debug.xcconfig"; path = "Target Support Files/Pods-ZKSyncExample/Pods-ZKSyncExample.debug.xcconfig"; sourceTree = "<group>"; };
-		AF37215B9FF2B83EA0479C88 /* Pods-ZKSyncExample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ZKSyncExample.release.xcconfig"; path = "Target Support Files/Pods-ZKSyncExample/Pods-ZKSyncExample.release.xcconfig"; sourceTree = "<group>"; };
-		BD97EC8DA29277BABEA0B4E4 /* Pods_ZKSyncExampleTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ZKSyncExampleTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		8CDF95587ABAE1B9D20870B8 /* Pods_ZKSyncExample.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ZKSyncExample.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		B32A403170B6D034173CC57B /* Pods_ZKSyncExampleTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ZKSyncExampleTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		C85DF1A9C0E9F565178B6EFF /* Pods-ZKSyncExampleTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ZKSyncExampleTests.debug.xcconfig"; path = "Target Support Files/Pods-ZKSyncExampleTests/Pods-ZKSyncExampleTests.debug.xcconfig"; sourceTree = "<group>"; };
+		D125D66FCFE2E45737AD405A /* Pods-ZKSyncExampleTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ZKSyncExampleTests.release.xcconfig"; path = "Target Support Files/Pods-ZKSyncExampleTests/Pods-ZKSyncExampleTests.release.xcconfig"; sourceTree = "<group>"; };
+		FA0ED7B779A7FCA148674128 /* Pods-ZKSyncExample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ZKSyncExample.debug.xcconfig"; path = "Target Support Files/Pods-ZKSyncExample/Pods-ZKSyncExample.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -87,7 +87,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				57E5048503FD0CE2FAD9DB48 /* Pods_ZKSyncExample.framework in Frameworks */,
+				56AA71BB4AA87D3D74F326D2 /* Pods_ZKSyncExample.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -95,7 +95,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				380D91C941169690952DB8D8 /* Pods_ZKSyncExampleTests.framework in Frameworks */,
+				2158B05245B51FC3C3493E17 /* Pods_ZKSyncExampleTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -105,10 +105,10 @@
 		5E906D6DA2122053999C8AD4 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				91946EDCC7AA66ED1F337C9D /* Pods-ZKSyncExample.debug.xcconfig */,
-				AF37215B9FF2B83EA0479C88 /* Pods-ZKSyncExample.release.xcconfig */,
-				4C3C624F3C39C15665764F2A /* Pods-ZKSyncExampleTests.debug.xcconfig */,
-				2982254753DB1AAE2DABE522 /* Pods-ZKSyncExampleTests.release.xcconfig */,
+				FA0ED7B779A7FCA148674128 /* Pods-ZKSyncExample.debug.xcconfig */,
+				2940ABF5BAC9C36FDE824858 /* Pods-ZKSyncExample.release.xcconfig */,
+				C85DF1A9C0E9F565178B6EFF /* Pods-ZKSyncExampleTests.debug.xcconfig */,
+				D125D66FCFE2E45737AD405A /* Pods-ZKSyncExampleTests.release.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -121,7 +121,7 @@
 				607FACE81AFB9204008FA782 /* Tests */,
 				607FACD11AFB9204008FA782 /* Products */,
 				5E906D6DA2122053999C8AD4 /* Pods */,
-				6A30D7885AC471674D357124 /* Frameworks */,
+				EF3FD0B33F0703515F55602B /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -162,15 +162,6 @@
 			name = "Podspec Metadata";
 			sourceTree = "<group>";
 		};
-		6A30D7885AC471674D357124 /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-				1F174EC994B8F39BF71D99A6 /* Pods_ZKSyncExample.framework */,
-				BD97EC8DA29277BABEA0B4E4 /* Pods_ZKSyncExampleTests.framework */,
-			);
-			name = Frameworks;
-			sourceTree = "<group>";
-		};
 		8A9CAE662690AA9000DABC41 /* ZKSyncExample */ = {
 			isa = PBXGroup;
 			children = (
@@ -206,6 +197,15 @@
 			path = ViewControllers;
 			sourceTree = "<group>";
 		};
+		EF3FD0B33F0703515F55602B /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				8CDF95587ABAE1B9D20870B8 /* Pods_ZKSyncExample.framework */,
+				B32A403170B6D034173CC57B /* Pods_ZKSyncExampleTests.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -213,11 +213,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 607FACEF1AFB9204008FA782 /* Build configuration list for PBXNativeTarget "ZKSyncExample" */;
 			buildPhases = (
-				50A72D85AB84BD439EA40A79 /* [CP] Check Pods Manifest.lock */,
+				C6EBCDC5AB8BAFE87AF642B4 /* [CP] Check Pods Manifest.lock */,
 				607FACCC1AFB9204008FA782 /* Sources */,
 				607FACCD1AFB9204008FA782 /* Frameworks */,
 				607FACCE1AFB9204008FA782 /* Resources */,
-				9033E752AEA4EF94BE6D9EA1 /* [CP] Embed Pods Frameworks */,
+				25D8D32E6641858B48764258 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -232,7 +232,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 607FACF21AFB9204008FA782 /* Build configuration list for PBXNativeTarget "ZKSyncExampleTests" */;
 			buildPhases = (
-				1100E7785085AA1899E010BB /* [CP] Check Pods Manifest.lock */,
+				B2D0C8FFE2F37CE484778D51 /* [CP] Check Pods Manifest.lock */,
 				607FACE11AFB9204008FA782 /* Sources */,
 				607FACE21AFB9204008FA782 /* Frameworks */,
 				607FACE31AFB9204008FA782 /* Resources */,
@@ -311,7 +311,41 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		1100E7785085AA1899E010BB /* [CP] Check Pods Manifest.lock */ = {
+		25D8D32E6641858B48764258 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-ZKSyncExample/Pods-ZKSyncExample-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/Alamofire/Alamofire.framework",
+				"${BUILT_PRODUCTS_DIR}/BigInt/BigInt.framework",
+				"${BUILT_PRODUCTS_DIR}/CryptoSwift/CryptoSwift.framework",
+				"${BUILT_PRODUCTS_DIR}/PromiseKit/PromiseKit.framework",
+				"${BUILT_PRODUCTS_DIR}/Starscream/Starscream.framework",
+				"${BUILT_PRODUCTS_DIR}/ZKSync/ZKSync.framework",
+				"${BUILT_PRODUCTS_DIR}/ZKSyncCrypto/ZKSyncCrypto.framework",
+				"${BUILT_PRODUCTS_DIR}/secp256k1.c/secp256k1.framework",
+				"${BUILT_PRODUCTS_DIR}/web3swift-zksync/web3swift_zksync.framework",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Alamofire.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/BigInt.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/CryptoSwift.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/PromiseKit.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Starscream.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/ZKSync.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/ZKSyncCrypto.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/secp256k1.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/web3swift_zksync.framework",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-ZKSyncExample/Pods-ZKSyncExample-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		B2D0C8FFE2F37CE484778D51 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -333,7 +367,7 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		50A72D85AB84BD439EA40A79 /* [CP] Check Pods Manifest.lock */ = {
+		C6EBCDC5AB8BAFE87AF642B4 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -353,40 +387,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		9033E752AEA4EF94BE6D9EA1 /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-ZKSyncExample/Pods-ZKSyncExample-frameworks.sh",
-				"${BUILT_PRODUCTS_DIR}/Alamofire/Alamofire.framework",
-				"${BUILT_PRODUCTS_DIR}/BigInt/BigInt.framework",
-				"${BUILT_PRODUCTS_DIR}/CryptoSwift/CryptoSwift.framework",
-				"${BUILT_PRODUCTS_DIR}/PromiseKit/PromiseKit.framework",
-				"${BUILT_PRODUCTS_DIR}/Starscream/Starscream.framework",
-				"${BUILT_PRODUCTS_DIR}/ZKSync/ZKSync.framework",
-				"${BUILT_PRODUCTS_DIR}/ZKSyncCrypto/ZKSyncCrypto.framework",
-				"${BUILT_PRODUCTS_DIR}/secp256k1.c/secp256k1.framework",
-				"${BUILT_PRODUCTS_DIR}/web3swift/web3swift.framework",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputPaths = (
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Alamofire.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/BigInt.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/CryptoSwift.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/PromiseKit.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Starscream.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/ZKSync.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/ZKSyncCrypto.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/secp256k1.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/web3swift.framework",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-ZKSyncExample/Pods-ZKSyncExample-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -563,7 +563,7 @@
 		};
 		607FACF01AFB9204008FA782 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 91946EDCC7AA66ED1F337C9D /* Pods-ZKSyncExample.debug.xcconfig */;
+			baseConfigurationReference = FA0ED7B779A7FCA148674128 /* Pods-ZKSyncExample.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = ZKSyncExample/Info.plist;
@@ -579,7 +579,7 @@
 		};
 		607FACF11AFB9204008FA782 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = AF37215B9FF2B83EA0479C88 /* Pods-ZKSyncExample.release.xcconfig */;
+			baseConfigurationReference = 2940ABF5BAC9C36FDE824858 /* Pods-ZKSyncExample.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = ZKSyncExample/Info.plist;
@@ -595,7 +595,7 @@
 		};
 		607FACF31AFB9204008FA782 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 4C3C624F3C39C15665764F2A /* Pods-ZKSyncExampleTests.debug.xcconfig */;
+			baseConfigurationReference = C85DF1A9C0E9F565178B6EFF /* Pods-ZKSyncExampleTests.debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -618,7 +618,7 @@
 		};
 		607FACF41AFB9204008FA782 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 2982254753DB1AAE2DABE522 /* Pods-ZKSyncExampleTests.release.xcconfig */;
+			baseConfigurationReference = D125D66FCFE2E45737AD405A /* Pods-ZKSyncExampleTests.release.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				FRAMEWORK_SEARCH_PATHS = (

--- a/Examples/CocoaPods/ZKSyncExample/ViewControllers/DepositViewController.swift
+++ b/Examples/CocoaPods/ZKSyncExample/ViewControllers/DepositViewController.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 import ZKSync
-import web3swift
+import web3swift_zksync
 import BigInt
 import PromiseKit
 

--- a/Examples/CocoaPods/ZKSyncExample/ViewControllers/MethodSelectionTableViewController.swift
+++ b/Examples/CocoaPods/ZKSyncExample/ViewControllers/MethodSelectionTableViewController.swift
@@ -9,7 +9,7 @@
 import UIKit
 import ZKSync
 import PromiseKit
-import web3swift
+import web3swift_zksync
 
 class MethodSelectionTableViewController: UITableViewController, WalletConsumer {
     var wallet: Wallet!

--- a/Examples/CocoaPods/ZKSyncExample/ViewControllers/TransferViewController.swift
+++ b/Examples/CocoaPods/ZKSyncExample/ViewControllers/TransferViewController.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 import ZKSync
-import web3swift
+import web3swift_zksync
 import BigInt
 import PromiseKit
 

--- a/Examples/CocoaPods/ZKSyncExample/ViewControllers/WithdrawViewController.swift
+++ b/Examples/CocoaPods/ZKSyncExample/ViewControllers/WithdrawViewController.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 import ZKSync
-import web3swift
+import web3swift_zksync
 import BigInt
 import PromiseKit
 

--- a/Sources/ZKSync/Ethereum/EthereumProvider.swift
+++ b/Sources/ZKSync/Ethereum/EthereumProvider.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 import BigInt
-import web3swift
+import web3swift_zksync
 import PromiseKit
 
 public enum EthereumProviderError: Error {

--- a/Sources/ZKSync/Ethereum/ZkSync.swift
+++ b/Sources/ZKSync/Ethereum/ZkSync.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 import BigInt
-import web3swift
+import web3swift_zksync
 import PromiseKit
 
 enum ZkSyncContractError: Error {

--- a/Sources/ZKSync/Ethereum/ZkSyncABI.swift
+++ b/Sources/ZKSync/Ethereum/ZkSyncABI.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-import web3swift
+import web3swift_zksync
 
 extension Web3.Utils {
     public static var zkSyncABI = """

--- a/Sources/ZKSync/Signer/Ethereum/DefaultEthSigner.swift
+++ b/Sources/ZKSync/Signer/Ethereum/DefaultEthSigner.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-import web3swift
+import web3swift_zksync
 import CryptoSwift
 import BigInt
 

--- a/Sources/ZKSync/Signer/Ethereum/EthSigner.swift
+++ b/Sources/ZKSync/Signer/Ethereum/EthSigner.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-import web3swift
+import web3swift_zksync
 import CryptoSwift
 import BigInt
 

--- a/Sources/ZKSync/Wallet/DefaultWallet.swift
+++ b/Sources/ZKSync/Wallet/DefaultWallet.swift
@@ -8,7 +8,7 @@
 import Foundation
 import BigInt
 import PromiseKit
-import web3swift
+import web3swift_zksync
 
 enum DefaultWalletError: Error {
     case internalError

--- a/Sources/ZKSync/Wallet/Wallet.swift
+++ b/Sources/ZKSync/Wallet/Wallet.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 import BigInt
-import web3swift
+import web3swift_zksync
 import PromiseKit
 
 public typealias ZKSyncCompletion<T> = (ZKSyncResult<T>) -> Void

--- a/ZKSync.podspec
+++ b/ZKSync.podspec
@@ -19,7 +19,7 @@ zkSync is a scaling and privacy engine for Ethereum. Its current functionality s
     
     s.dependency 'ZKSyncCrypto', '0.0.9-spm'
     s.dependency 'Alamofire', '~> 5.0'
-    s.dependency 'web3swift'
+    s.dependency 'web3swift-zksync', '2.4.0-zksync'
 
     s.source_files = 'Sources/ZKSync/**/*'
 end


### PR DESCRIPTION
Update to temporary version `2.4.0-zksync` of `web3swift-zksync` fork to fix build issues on Xcode 12.5 and higher. 

Fork can be found here: https://github.com/zksync-sdk/web3swift.