### PR TITLE
Use posix locale to ensure consistent formatting of decimal numbers

### DIFF
--- a/Sources/ZKSync/Signer/Utils/Utils.swift
+++ b/Sources/ZKSync/Signer/Utils/Utils.swift
@@ -32,6 +32,7 @@ struct Utils {
 
     private static var Formatter: NumberFormatter = {
         let formatter = NumberFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
         formatter.minimumFractionDigits = 1
         formatter.maximumFractionDigits = 18
         return formatter


### PR DESCRIPTION
The internal decimal formatter is using the device's region locale meaning depending on the region it will use a different decimal separator and that will interfere with signing of transactions requiring an Ethereum signature. 

As an example, signing an order in a device in the United States will sign an order for 5 DAI using a dot, `"Order for 5.0 DAI ..."`, where a device in France will sign the same order for 5 DAI using a comma, `"Order for 5,0 DAI..."`, leading to a mismatch of the Ethereum signature that the service is expecting. 