### PR TITLE
Update dependencies.

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -25,4 +25,4 @@ jobs:
 
     - name: Run tests
       working-directory: ./Examples/CocoaPods
-      run: xcodebuild -workspace ZKSyncExample.xcworkspace -scheme ZKSyncExample -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 13 Pro Max,OS=15.0' test
+      run: xcodebuild -workspace ZKSyncExample.xcworkspace -scheme ZKSyncExample -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 13 Pro Max,OS=15.2' test

--- a/Examples/CocoaPods/Podfile.lock
+++ b/Examples/CocoaPods/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
-  - Alamofire (5.4.3)
+  - Alamofire (5.5.0)
   - BigInt (5.2.0)
-  - CryptoSwift (1.4.1)
+  - CryptoSwift (1.4.2)
   - PromiseKit (6.15.3):
     - PromiseKit/CorePromise (= 6.15.3)
     - PromiseKit/Foundation (= 6.15.3)
@@ -13,15 +13,15 @@ PODS:
     - PromiseKit/CorePromise
   - secp256k1.c (0.1.2)
   - Starscream (4.0.4)
-  - web3swift-zksync (2.4.0-zksync):
-    - BigInt (~> 5.2)
-    - CryptoSwift (~> 1.4.0)
+  - web3swift (2.5.0):
+    - BigInt (~> 5.2.0)
+    - CryptoSwift (~> 1.4.2)
     - PromiseKit (~> 6.15.3)
     - secp256k1.c (~> 0.1)
     - Starscream (~> 4.0.4)
   - ZKSync (0.0.3):
     - Alamofire (~> 5.0)
-    - web3swift-zksync (= 2.4.0-zksync)
+    - web3swift (~> 2.5.0)
     - ZKSyncCrypto (= 0.0.9-spm)
   - ZKSyncCrypto (0.0.9-spm)
 
@@ -36,7 +36,7 @@ SPEC REPOS:
     - PromiseKit
     - secp256k1.c
     - Starscream
-    - web3swift-zksync
+    - web3swift
     - ZKSyncCrypto
 
 EXTERNAL SOURCES:
@@ -44,16 +44,16 @@ EXTERNAL SOURCES:
     :path: "../../"
 
 SPEC CHECKSUMS:
-  Alamofire: e447a2774a40c996748296fa2c55112fdbbc42f9
+  Alamofire: 1c4fb5369c3fe93d2857c780d8bbe09f06f97e7c
   BigInt: f668a80089607f521586bbe29513d708491ef2f7
-  CryptoSwift: 0bc800a7e6a24c4fc9ebeab97d44b0d5f73a78bd
+  CryptoSwift: a532e74ed010f8c95f611d00b8bbae42e9fe7c17
   PromiseKit: 3b2b6995e51a954c46dbc550ce3da44fbfb563c5
   secp256k1.c: db47b726585d80f027423682eb369729e61b3b20
   Starscream: 5178aed56b316f13fa3bc55694e583d35dd414d9
-  web3swift-zksync: f069cac51c03dd98e28fc4480d64b4e9b91e2aff
-  ZKSync: 2c3a7a3ca241473fea02b6fc6275a84484536c11
+  web3swift: 31ecb7a7da543f851344cdd64badea94c439b0d9
+  ZKSync: 51baca54847c46220571efdf9fa80099372117ff
   ZKSyncCrypto: ff0662eb0cff69ab3e40564a45a07cbcafe1ccf0
 
 PODFILE CHECKSUM: 19f2bc7b77d611151be6a9850baac7dbb61b1e85
 
-COCOAPODS: 1.11.0
+COCOAPODS: 1.11.2

--- a/Examples/CocoaPods/Tests/IntegrationCreate2ShortFlowTests.swift
+++ b/Examples/CocoaPods/Tests/IntegrationCreate2ShortFlowTests.swift
@@ -8,7 +8,7 @@
 
 import XCTest
 @testable import ZKSync
-import web3swift_zksync
+import web3swift
 import PromiseKit
 
 class IntegrationCreate2ShortFlowTests: XCTestCase {

--- a/Examples/CocoaPods/Tests/IntegrationFlowTests.swift
+++ b/Examples/CocoaPods/Tests/IntegrationFlowTests.swift
@@ -8,7 +8,7 @@
 
 import XCTest
 @testable import ZKSync
-import web3swift_zksync
+import web3swift
 import PromiseKit
 
 enum InternalError: LocalizedError {

--- a/Examples/CocoaPods/ZKSyncExample.xcodeproj/project.pbxproj
+++ b/Examples/CocoaPods/ZKSyncExample.xcodeproj/project.pbxproj
@@ -299,7 +299,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0830;
-				LastUpgradeCheck = 1250;
+				LastUpgradeCheck = 1320;
 				ORGANIZATIONNAME = CocoaPods;
 				TargetAttributes = {
 					607FACCF1AFB9204008FA782 = {
@@ -371,7 +371,7 @@
 				"${BUILT_PRODUCTS_DIR}/ZKSync/ZKSync.framework",
 				"${BUILT_PRODUCTS_DIR}/ZKSyncCrypto/ZKSyncCrypto.framework",
 				"${BUILT_PRODUCTS_DIR}/secp256k1.c/secp256k1.framework",
-				"${BUILT_PRODUCTS_DIR}/web3swift-zksync/web3swift_zksync.framework",
+				"${BUILT_PRODUCTS_DIR}/web3swift/web3swift.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
@@ -383,7 +383,7 @@
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/ZKSync.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/ZKSyncCrypto.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/secp256k1.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/web3swift_zksync.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/web3swift.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/Examples/CocoaPods/ZKSyncExample.xcodeproj/xcshareddata/xcschemes/ZKSyncExample.xcscheme
+++ b/Examples/CocoaPods/ZKSyncExample.xcodeproj/xcshareddata/xcschemes/ZKSyncExample.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1250"
+   LastUpgradeVersion = "1320"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Examples/CocoaPods/ZKSyncExample/ViewControllers/DepositViewController.swift
+++ b/Examples/CocoaPods/ZKSyncExample/ViewControllers/DepositViewController.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 import ZKSync
-import web3swift_zksync
+import web3swift
 import PromiseKit
 
 class DepositViewController: UIViewController, WalletConsumer {

--- a/Examples/CocoaPods/ZKSyncExample/ViewControllers/MethodSelectionTableViewController.swift
+++ b/Examples/CocoaPods/ZKSyncExample/ViewControllers/MethodSelectionTableViewController.swift
@@ -9,7 +9,7 @@
 import UIKit
 import ZKSync
 import PromiseKit
-import web3swift_zksync
+import web3swift
 
 class MethodSelectionTableViewController: UITableViewController, WalletConsumer {
 

--- a/Examples/CocoaPods/ZKSyncExample/ViewControllers/TransferViewController.swift
+++ b/Examples/CocoaPods/ZKSyncExample/ViewControllers/TransferViewController.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 import ZKSync
-import web3swift_zksync
+import web3swift
 import PromiseKit
 
 class TransferViewController: UIViewController, WalletConsumer {

--- a/Examples/CocoaPods/ZKSyncExample/ViewControllers/WithdrawViewController.swift
+++ b/Examples/CocoaPods/ZKSyncExample/ViewControllers/WithdrawViewController.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 import ZKSync
-import web3swift_zksync
+import web3swift
 import PromiseKit
 
 class WithdrawViewController: UIViewController, WalletConsumer {

--- a/Examples/SPM/ZKSyncExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Examples/SPM/ZKSyncExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/Alamofire/Alamofire.git",
         "state": {
           "branch": null,
-          "revision": "f96b619bcb2383b43d898402283924b80e2c4bae",
-          "version": "5.4.3"
+          "revision": "f82c23a8a7ef8dc1a49a8bfc6a96883e79121864",
+          "version": "5.5.0"
         }
       },
       {
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/attaswift/BigInt.git",
         "state": {
           "branch": null,
-          "revision": "889a1ecacd73ccc189c5cb29288048f186c44ed9",
-          "version": "5.2.1"
+          "revision": "0ed110f7555c34ff468e72e1686e59721f2b0da6",
+          "version": "5.3.0"
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/krzyzanowskim/CryptoSwift.git",
         "state": {
           "branch": null,
-          "revision": "8d4f6384e0a8cc41f2005247241dd553963a492a",
-          "version": "1.4.1"
+          "revision": "12f2389aca4a07e0dd54c86ec23d0721ed88b8db",
+          "version": "1.4.3"
         }
       },
       {
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/mxcl/PromiseKit.git",
         "state": {
           "branch": null,
-          "revision": "d2f7ba14bcdc45e18f4f60ad9df883fb9055f081",
-          "version": "6.15.3"
+          "revision": "7b07b214dacecb22ca4b680531c7e981d52483f9",
+          "version": "6.16.3"
         }
       },
       {
@@ -48,10 +48,10 @@
       },
       {
         "package": "Web3swift",
-        "repositoryURL": "https://github.com/skywinder/web3swift.git",
+        "repositoryURL": "https://github.com/zksync-sdk/web3swift.git",
         "state": {
           "branch": "develop",
-          "revision": "262d48bc248d97aa53f25719acadb49c8527b25b",
+          "revision": "b7f162ce6c289589b465c739997d5c5a11be5120",
           "version": null
         }
       },
@@ -60,7 +60,7 @@
         "repositoryURL": "https://github.com/zksync-sdk/zksync-swift.git",
         "state": {
           "branch": "master",
-          "revision": "21a52ec1d0d6c841bba26da828cd607a40396e69",
+          "revision": "6ccc483a6ca6c936d32404c76b8caa1e90876d78",
           "version": null
         }
       }

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/Alamofire/Alamofire.git",
         "state": {
           "branch": null,
-          "revision": "f96b619bcb2383b43d898402283924b80e2c4bae",
-          "version": "5.4.3"
+          "revision": "f82c23a8a7ef8dc1a49a8bfc6a96883e79121864",
+          "version": "5.5.0"
         }
       },
       {
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/attaswift/BigInt.git",
         "state": {
           "branch": null,
-          "revision": "889a1ecacd73ccc189c5cb29288048f186c44ed9",
-          "version": "5.2.1"
+          "revision": "0ed110f7555c34ff468e72e1686e59721f2b0da6",
+          "version": "5.3.0"
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/krzyzanowskim/CryptoSwift.git",
         "state": {
           "branch": null,
-          "revision": "8d4f6384e0a8cc41f2005247241dd553963a492a",
-          "version": "1.4.1"
+          "revision": "12f2389aca4a07e0dd54c86ec23d0721ed88b8db",
+          "version": "1.4.3"
         }
       },
       {
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/mxcl/PromiseKit.git",
         "state": {
           "branch": null,
-          "revision": "d2f7ba14bcdc45e18f4f60ad9df883fb9055f081",
-          "version": "6.15.3"
+          "revision": "7b07b214dacecb22ca4b680531c7e981d52483f9",
+          "version": "6.16.3"
         }
       },
       {
@@ -48,11 +48,11 @@
       },
       {
         "package": "Web3swift",
-        "repositoryURL": "https://github.com/zksync-sdk/web3swift.git",
+        "repositoryURL": "https://github.com/skywinder/web3swift.git",
         "state": {
-          "branch": "develop",
-          "revision": "b7f162ce6c289589b465c739997d5c5a11be5120",
-          "version": null
+          "branch": null,
+          "revision": "ff538e874cf2f6ca0f5736bfd7deb89f4a0bd624",
+          "version": "2.5.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -18,8 +18,8 @@ let package = Package(
     dependencies: [
         .package(
             name: "Web3swift",
-            url: "https://github.com/zksync-sdk/web3swift.git",
-            .branch("develop")
+            url: "https://github.com/skywinder/web3swift.git",
+            from: "2.5.0"
         ),
         .package(
             name: "Alamofire",

--- a/Sources/ZKSync/Ethereum/EthereumProvider.swift
+++ b/Sources/ZKSync/Ethereum/EthereumProvider.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 import BigInt
-import web3swift_zksync
+import web3swift
 import PromiseKit
 
 public enum EthereumProviderError: Error {

--- a/Sources/ZKSync/Ethereum/ZkSync.swift
+++ b/Sources/ZKSync/Ethereum/ZkSync.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 import BigInt
-import web3swift_zksync
+import web3swift
 import PromiseKit
 
 enum ZkSyncContractError: Error {

--- a/Sources/ZKSync/Ethereum/ZkSyncABI.swift
+++ b/Sources/ZKSync/Ethereum/ZkSyncABI.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-import web3swift_zksync
+import web3swift
 
 extension Web3.Utils {
     public static var zkSyncABI = """

--- a/Sources/ZKSync/Signer/Ethereum/Create2EthSigner.swift
+++ b/Sources/ZKSync/Signer/Ethereum/Create2EthSigner.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-import web3swift_zksync
+import web3swift
 import BigInt
 
 public class Create2EthSigner: EthSigner {

--- a/Sources/ZKSync/Signer/Ethereum/DefaultEthSigner.swift
+++ b/Sources/ZKSync/Signer/Ethereum/DefaultEthSigner.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-import web3swift_zksync
+import web3swift
 import BigInt
 
 public class DefaultEthSigner: EthSigner {

--- a/Sources/ZKSync/Signer/Ethereum/EthSigner.swift
+++ b/Sources/ZKSync/Signer/Ethereum/EthSigner.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-import web3swift_zksync
+import web3swift
 import BigInt
 
 public protocol EthSigner {

--- a/Sources/ZKSync/Wallet/DefaultWallet.swift
+++ b/Sources/ZKSync/Wallet/DefaultWallet.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 import PromiseKit
-import web3swift_zksync
+import web3swift
 
 enum DefaultWalletError: Error {
     case internalError

--- a/Sources/ZKSync/Wallet/Wallet.swift
+++ b/Sources/ZKSync/Wallet/Wallet.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 import BigInt
-import web3swift_zksync
+import web3swift
 import PromiseKit
 
 public typealias ZKSyncCompletion<T> = (ZKSyncResult<T>) -> Void

--- a/ZKSync.podspec
+++ b/ZKSync.podspec
@@ -19,7 +19,7 @@ zkSync is a scaling and privacy engine for Ethereum. Its current functionality s
     
     s.dependency 'ZKSyncCrypto', '0.0.9-spm'
     s.dependency 'Alamofire', '~> 5.0'
-    s.dependency 'web3swift-zksync', '2.4.0-zksync'
+    s.dependency 'web3swift', '~> 2.5.0'
 
     s.source_files = 'Sources/ZKSync/**/*'
 end


### PR DESCRIPTION
PR updates web3swift to `v2.5.0`. Fork from https://github.com/zksync-sdk/web3swift is no longer needed, since build issues on Xcode 13 were fixed.